### PR TITLE
bumping JSON::Any version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use ExtUtils::MakeMaker;
- 
+
 WriteMakefile(
     NAME                => 'WWW::Facebook::API',
     AUTHOR              => 'David Romano <unobe@cpan.org>',
@@ -13,7 +13,7 @@ WriteMakefile(
         'version'           => 0,
         'Crypt::SSLeay'     => 0,
         'Digest::MD5'       => 0,
-        'JSON::Any'         => 0,
+        'JSON::Any'         => 1.33,
         'Time::HiRes'       => 0,
         'LWP::UserAgent'    => 0,
         'Readonly'          => 0,


### PR DESCRIPTION
Hi there!

First of all, thank you for writing and maintaining WWW::Facebook::API. I have seen some [failing CPAN Testers reports](http://www.cpantesters.org/distro/W/WWW-Facebook-API.html?oncpan=1&distmat=1&version=0.4.18&grade=3) lately, apparently due to the absence of a valid JSON parser on the tester's box.

In order to fix that, I have bumped the required version for JSON::Any to 1.33, a somewhat recent (~2014) which will auto-install at least one backend JSON parser if none is found.

I should also note that [JSON::Any](https://metacpan.org/pod/JSON::Any) has been deprecated for quite some time now in favour of [JSON::MaybeXS](https://metacpan.org/pod/JSON::MaybeXS). I can write you a patch for this, but since it's a bit more involving, I figured I rather consult with you first :)

Hope this helps! Cheers!
