### PR TITLE
replacing Readonly with Const::Fast

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ WriteMakefile(
         'JSON::Any'         => 0,
         'Time::HiRes'       => 0,
         'LWP::UserAgent'    => 0,
-        'Readonly'          => 0,
+        'Const::Fast'       => 0,
     },
     META_MERGE          => {
         resources => {

--- a/lib/WWW/Facebook/API/Auth.pm
+++ b/lib/WWW/Facebook/API/Auth.pm
@@ -7,8 +7,8 @@ use warnings;
 use strict;
 use Carp;
 
-use Readonly;
-Readonly my $DEFAULT_SLEEP => 15;
+use Const::Fast;
+const my $DEFAULT_SLEEP => 15;
 
 sub create_token {
     my $self = shift;


### PR DESCRIPTION
Hello!

This is another very simple patch to WWW::Facebook::API, replacing the deprecated Readonly module with the newer Const::Fast.

According to Const::Fast's documentation, there are some serious issues of Readonly that aren't easily fixable without breaking backwards compatibility in subtle ways. In particular Readonly's use of ties is a source of subtle bugs and bad performance. Instead, Const::Fast uses the builtin readonly feature of perl, making access to the variables just as fast as any normal variable without the weird side-effects of ties. Readonly can do the same for scalars when Readonly::XS is installed, but chooses not to do so in the most common case.

Hope it helps! Cheers!